### PR TITLE
Add Sketch object ID overrides

### DIFF
--- a/html2asketch/model/base.js
+++ b/html2asketch/model/base.js
@@ -3,11 +3,11 @@ import {generateID, RESIZING_CONSTRAINTS, calculateResizingConstraintValue} from
 const DEFAULT_USER_INFO_SCOPE = 'html-sketchapp';
 
 class Base {
-  constructor() {
+  constructor({ id } = {}) {
     this._class = null;
     this._layers = [];
     this._style = null;
-    this._objectID = generateID();
+    this._objectID = id || generateID();
     this._name = '';
     this._userInfo = null;
     this.setResizingConstraint(RESIZING_CONSTRAINTS.NONE);
@@ -24,6 +24,10 @@ class Base {
 
   getID() {
     return this._objectID;
+  }
+
+  setId(id) {
+    this._objectID = id;
   }
 
   // scope defines which Sketch plugin will have access to provided data via Settings.setLayerSettingForKey

--- a/html2asketch/model/document.js
+++ b/html2asketch/model/document.js
@@ -8,10 +8,10 @@ function pageToPageReference(page) {
   };
 }
 
-function textStyleToSharedStyle(textLayer) {
+function textStyleToSharedStyle(textLayer, id) {
   return {
     '_class': 'sharedStyle',
-    'do_objectID': generateID(),
+    'do_objectID': id || generateID(),
     name: textLayer._name,
     'style': textLayer._style.toJSON()
   };
@@ -29,12 +29,16 @@ class Document {
     this._name = name;
   }
 
+  setId(id) {
+    this._objectID = id;
+  }
+
   addPage(page) {
     this._pages.push(page);
   }
 
-  addTextStyle(textLayer) {
-    this._textStyles.push(textStyleToSharedStyle(textLayer));
+  addTextStyle(textLayer, id) {
+    this._textStyles.push(textStyleToSharedStyle(textLayer, id));
   }
 
   addColor(color) {

--- a/html2asketch/model/symbolInstance.js
+++ b/html2asketch/model/symbolInstance.js
@@ -11,6 +11,10 @@ class SymbolInstance extends Base {
     this._symbolID = symbolID;
   }
 
+  setId(id) {
+    this._symbolID = id;
+  }
+
   toJSON() {
     const obj = super.toJSON();
 

--- a/html2asketch/model/symbolMaster.js
+++ b/html2asketch/model/symbolMaster.js
@@ -14,6 +14,7 @@ class SymbolMaster extends Base {
   }
 
   setId(id) {
+    super.setId(id);
     this._symbolID = id;
   }
 

--- a/html2asketch/model/text.js
+++ b/html2asketch/model/text.js
@@ -2,8 +2,8 @@ import Base from './base';
 import {RESIZING_CONSTRAINTS} from '../helpers/utils';
 
 class Text extends Base {
-  constructor({x, y, width, height, text, style, multiline}) {
-    super();
+  constructor({x, y, width, height, text, style, multiline, id}) {
+    super({id});
     this._class = 'text';
     this._x = x;
     this._y = y;

--- a/html2asketch/nodeToSketchLayers.js
+++ b/html2asketch/nodeToSketchLayers.js
@@ -322,7 +322,18 @@ export default function nodeToSketchLayers(node, options) {
 
       const textValue = fixWhiteSpace(textNode.nodeValue, whiteSpace);
 
+      let id;
+
+      if (textNode.parentNode && textNode.parentNode.dataset) {
+        const {sketchId, sketchText} = textNode.parentNode.dataset;
+
+        if (sketchId || sketchText) {
+          id = `text:${sketchId || sketchText}`;
+        }
+      }
+
       const text = new Text({
+        id,
         x: textBCR.left,
         y: textBCR.top + fixY,
         width: textBCR.right - textBCR.left,


### PR DESCRIPTION
Uses text node parent dataset attributes (`sketchId` and `sketchText`), which might make more sense for it to be in `html-sketchapp-cli` instead?